### PR TITLE
fix: add unique id to definitions

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,10 @@ const stringHash = require('string-hash');
 const hslTriad = require('hsl-triad');
 const hslRgb = require('hsl-rgb');
 
+function uniqueID() {
+ return Math.floor(Math.random() * Date.now())
+}
+
 const avatar = (str, size) => {
   const hash = stringHash(str);
   const colors = hslTriad(hash % 360, 1, 0.5);
@@ -9,17 +13,17 @@ const avatar = (str, size) => {
   const color2 = hslRgb(colors[1][0], colors[1][1], colors[1][2]);
   const color1str = `rgb(${ color1[0] }, ${ color1[1] }, ${ color1[2] })`;
   const color2str = `rgb(${ color2[0] }, ${ color2[1] }, ${ color2[2] })`;
-  
+  const id = uniqueID()
   return `<?xml version="1.0" encoding="UTF-8"?>
 <svg ${ size != undefined ? `width="${size}px" height="${size}px"` : '' } viewBox="0 0 80 80" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
-    <linearGradient x1="0%" y1="0%" x2="100%" y2="100%" id="g">
+    <linearGradient x1="0%" y1="0%" x2="100%" y2="100%" id="${id}">
       <stop stop-color="${color1str}" offset="0%"></stop>
       <stop stop-color="${color2str}" offset="100%"></stop>
     </linearGradient>
   </defs>
-  <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-    <rect id="Rectangle" fill="url(#g)" x="0" y="0" width="80" height="80"></rect>
+  <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <rect id="Rectangle" fill="url(#${id})" x="0" y="0" width="80" height="80"></rect>
   </g>
 </svg>`;
 };


### PR DESCRIPTION
You are not able to run multiple instances on the same time, because they all take the same value of the last id `#g`, 

This fix ensures that each instance has a fresh id, allowing multiple avatars on the same page